### PR TITLE
Update influxdb.js - change the measurement to use dots

### DIFF
--- a/src/server/influxdb.js
+++ b/src/server/influxdb.js
@@ -130,7 +130,7 @@ class InfluxDB {
     } else if (typeof value !== 'number') {
       return
     }
-
+    measurement = measurement.replace(/\//g,'.')
     const point = {
       timestamp: new Date(),
       measurement: measurement,


### PR DESCRIPTION
Use . (dot) instead of / as the separator in measurement. This enables $1,$2,$3 functionality in grafana, and makes it possible to use regexes on measurements.
