### PR TITLE
Add support for dot separated measurements

### DIFF
--- a/src/server/influxdb.js
+++ b/src/server/influxdb.js
@@ -130,14 +130,15 @@ class InfluxDB {
     } else if (typeof value !== 'number') {
       return
     }
-
+    measurement = measurement.replace(/\//g, '.')
     const point = {
       timestamp: new Date(),
       measurement: measurement,
       tags: {
         portalId: portalId,
         instanceNumber: instanceNumber,
-        name: name || portalId
+        name: name || portalId,
+        topic: measurement
       },
       fields: {
         [valueKey]: value


### PR DESCRIPTION
Add topic as a tag enabling further functionality in grafana.
Use a dot in the measurement instead of / such that we can use $1,$2,$3, etc for aliases in Grafana.

This will break a lot of dashboards currently in use, but the benefits outweigh the little bit of work to straighten it out.