### PR TITLE
feat(influxdb): allow measurement separator to be overriden

### DIFF
--- a/src/client/views/settings/InfluxDB.js
+++ b/src/client/views/settings/InfluxDB.js
@@ -6,6 +6,7 @@ import {
   CForm,
   CFormLabel,
   CFormInput,
+  CFormSelect,
   CButton,
 } from '@coreui/react'
 
@@ -81,6 +82,16 @@ function InfluxDB (props) {
                 value={config.influxdb.password}
                 onChange={event => handleFormInputChange(event)}
               />
+            </div>
+            <div className="mb-3">
+              <CFormLabel htmlFor="format">Measurement Format</CFormLabel>
+              <CFormSelect name="format"
+                value={config.influxdb.format}
+                onChange={event => handleFormInputChange(event)}
+              >
+                <option value="/">system/Dc/Battery/Soc</option>
+                <option value=".">system.Dc.Battery.Soc</option>
+              </CFormSelect>
             </div>
           </CForm>
         </CCardBody>

--- a/src/server/influxdb.js
+++ b/src/server/influxdb.js
@@ -130,7 +130,12 @@ class InfluxDB {
     } else if (typeof value !== 'number') {
       return
     }
-
+    // replace separator
+    const separator = this.app.config.influxdb.format
+    if (separator && separator !== '/') {
+      measurement = measurement.replace(/\//g, separator)
+    }
+    // prepare influxdb point
     const point = {
       timestamp: new Date(),
       measurement: measurement,


### PR DESCRIPTION
This is a prototype that allows InfluxDB measurement separator to be changed from the slash (/) used by DBus to dot (.) that allows grouping in InfluxDB queries by positional parameters.

The Admin UI configuration section allows to choose measurement separator, which is then stored to config file and used to replace measurement name in realtime.

Addresses: https://github.com/victronenergy/venus-influx-loader/issues/82

<img width="1296" alt="Screenshot 2024-05-17 at 20 07 02" src="https://github.com/victronenergy/venus-influx-loader/assets/249814/90fd732c-26d3-4bcb-9f94-70d8fb23b0a4">
