### PR TITLE
Custom MQTT subscriptions 

### DIFF
--- a/src/client/views/settings/AutoExpiryOptionList.tsx
+++ b/src/client/views/settings/AutoExpiryOptionList.tsx
@@ -9,7 +9,6 @@ export interface AutoExpiryOptionListProps {
   portalId: string
   configuredExpiryTime?: number
   defaultExpiryDuration?: number
-  value?: number
   onSelectionDidChange: (_event: React.ChangeEvent<HTMLSelectElement>, _index: number, _portalId: string) => void
 }
 

--- a/src/client/views/settings/DeviceList.tsx
+++ b/src/client/views/settings/DeviceList.tsx
@@ -14,12 +14,16 @@ interface DeviceListProps {
   settings: AppUPNPConfig | AppVRMConfig
   referenceTime: number
   expirySettings: AppDataCollectionExpiryConfig
-  subscriptionSettings: AppDeviceSubscriptionsConfig
+  mqttSubscriptionsSettings: AppDeviceSubscriptionsConfig
   onEnablePortalChange: React.ChangeEventHandler<HTMLInputElement>
   onEnableAllPortalsChange: React.ChangeEventHandler<HTMLInputElement>
   availablePortalIds: DiscoveredDevice[]
   defaultExpiryDuration?: number
-  onPortalSubscriptionChange: (_event: React.ChangeEvent<HTMLSelectElement>, _index: number, _portalId: string) => void
+  onPortalMQTTSubscriptionsChange: (
+    _event: React.ChangeEvent<HTMLSelectElement>,
+    _index: number,
+    _portalId: string,
+  ) => void
   onPortalExpiryChange: (_event: React.ChangeEvent<HTMLSelectElement>, _index: number, _portalId: string) => void
 }
 
@@ -57,8 +61,8 @@ export function DeviceList(props: DeviceListProps) {
                   <MQTTSubscriptionsOptionList
                     index={index}
                     portalId={element.portalId}
-                    configuredMQTTSubscriptions={props.subscriptionSettings[element.portalId]}
-                    onSelectionDidChange={props.onPortalSubscriptionChange}
+                    configuredMQTTSubscriptions={props.mqttSubscriptionsSettings[element.portalId]}
+                    onSelectionDidChange={props.onPortalMQTTSubscriptionsChange}
                   />
                 </CTableDataCell>
                 {props.defaultExpiryDuration && (

--- a/src/client/views/settings/DeviceList.tsx
+++ b/src/client/views/settings/DeviceList.tsx
@@ -3,6 +3,7 @@ import { CFormCheck, CTable, CTableHead, CTableBody, CTableHeaderCell, CTableDat
 import { AppDataCollectionExpiryConfig, AppUPNPConfig, AppVRMConfig } from "../../../shared/types"
 import { DiscoveredDevice } from "../../../shared/state"
 import { AutoExpiryOptionList } from "./AutoExpiryOptionList"
+import { MQTTSubscriptionsOptionList } from "./MQTTSubscriptionsOptionList"
 
 interface DeviceListProps {
   hidden?: boolean
@@ -13,6 +14,7 @@ interface DeviceListProps {
   onEnableAllPortalsChange: React.ChangeEventHandler<HTMLInputElement>
   availablePortalIds: DiscoveredDevice[]
   defaultExpiryDuration?: number
+  onPortalSubscriptionChange: (_event: React.ChangeEvent<HTMLSelectElement>, _index: number, _portalId: string) => void
   onPortalExpiryChange: (_event: React.ChangeEvent<HTMLSelectElement>, _index: number, _portalId: string) => void
 }
 
@@ -23,6 +25,7 @@ export function DeviceList(props: DeviceListProps) {
         <CTableRow>
           <CTableHeaderCell>Installation Name</CTableHeaderCell>
           <CTableHeaderCell>Portal ID</CTableHeaderCell>
+          <CTableHeaderCell>Subscription</CTableHeaderCell>
           {props.defaultExpiryDuration && <CTableHeaderCell>Auto Expire Data Collection</CTableHeaderCell>}
           <CTableHeaderCell>
             <CFormCheck
@@ -45,6 +48,13 @@ export function DeviceList(props: DeviceListProps) {
               <CTableRow key={element.portalId}>
                 <CTableDataCell>{element.name}</CTableDataCell>
                 <CTableDataCell>{element.portalId}</CTableDataCell>
+                <CTableDataCell>
+                  <MQTTSubscriptionsOptionList
+                    index={index}
+                    portalId={element.portalId}
+                    onSelectionDidChange={props.onPortalSubscriptionChange}
+                  />
+                </CTableDataCell>
                 {props.defaultExpiryDuration && (
                   <CTableDataCell>
                     <AutoExpiryOptionList

--- a/src/client/views/settings/DeviceList.tsx
+++ b/src/client/views/settings/DeviceList.tsx
@@ -1,6 +1,10 @@
 import React from "react"
 import { CFormCheck, CTable, CTableHead, CTableBody, CTableHeaderCell, CTableDataCell, CTableRow } from "@coreui/react"
-import { AppDataCollectionExpiryConfig, AppUPNPConfig, AppVRMConfig } from "../../../shared/types"
+import AppDeviceSubscriptionsConfig, {
+  AppDataCollectionExpiryConfig,
+  AppUPNPConfig,
+  AppVRMConfig,
+} from "../../../shared/types"
 import { DiscoveredDevice } from "../../../shared/state"
 import { AutoExpiryOptionList } from "./AutoExpiryOptionList"
 import { MQTTSubscriptionsOptionList } from "./MQTTSubscriptionsOptionList"
@@ -10,6 +14,7 @@ interface DeviceListProps {
   settings: AppUPNPConfig | AppVRMConfig
   referenceTime: number
   expirySettings: AppDataCollectionExpiryConfig
+  subscriptionSettings: AppDeviceSubscriptionsConfig
   onEnablePortalChange: React.ChangeEventHandler<HTMLInputElement>
   onEnableAllPortalsChange: React.ChangeEventHandler<HTMLInputElement>
   availablePortalIds: DiscoveredDevice[]
@@ -52,6 +57,7 @@ export function DeviceList(props: DeviceListProps) {
                   <MQTTSubscriptionsOptionList
                     index={index}
                     portalId={element.portalId}
+                    configuredMQTTSubscriptions={props.subscriptionSettings[element.portalId]}
                     onSelectionDidChange={props.onPortalSubscriptionChange}
                   />
                 </CTableDataCell>

--- a/src/client/views/settings/Discovery.tsx
+++ b/src/client/views/settings/Discovery.tsx
@@ -150,13 +150,13 @@ function Discovery() {
               settings={temporaryConfig.upnp}
               referenceTime={referenceTime}
               expirySettings={temporaryConfig.upnp.expiry}
-              subscriptionSettings={temporaryConfig.upnp.subscriptions}
+              mqttSubscriptionsSettings={temporaryConfig.upnp.subscriptions}
               availablePortalIds={upnpDiscovered}
               onEnablePortalChange={handleEnablePortalChange}
               onEnableAllPortalsChange={handleEnableAllPortalsChange}
               defaultExpiryDuration={defaultExpiryDuration}
               onPortalExpiryChange={handlePortalExpiryChange}
-              onPortalSubscriptionChange={handlePortalSubscriptionChange}
+              onPortalMQTTSubscriptionsChange={handlePortalSubscriptionChange}
             />
           </CForm>
         </CCardBody>

--- a/src/client/views/settings/Discovery.tsx
+++ b/src/client/views/settings/Discovery.tsx
@@ -6,7 +6,7 @@ import { useGetConfig, usePutConfig } from "../../hooks/useAdminApi"
 import { useFormValidation, extractParameterNameAndValue } from "../../hooks/useFormValidation"
 import { DeviceList } from "./DeviceList"
 import { useEffect, useState } from "react"
-import { AppConfig } from "../../../shared/types"
+import { AppConfig, VenusMQTTTopic } from "../../../shared/types"
 import { AppState } from "../../store"
 import { WebSocketStatus } from "./WebsocketStatus"
 
@@ -97,6 +97,22 @@ function Discovery() {
     setIsTemporaryConfigDirty(true)
   }
 
+  function handlePortalSubscriptionChange(
+    event: React.ChangeEvent<HTMLSelectElement>,
+    _index: number,
+    portalId: string,
+  ) {
+    const clone = { ...temporaryConfig!! }
+    const value = String(event.target.value) as VenusMQTTTopic
+    if (value) {
+      clone.upnp.subscriptions[portalId] = [value]
+    } else {
+      delete clone.upnp.subscriptions[portalId]
+    }
+    setTemporaryConfig(clone)
+    setIsTemporaryConfigDirty(true)
+  }
+
   function handlePortalExpiryChange(event: React.ChangeEvent<HTMLSelectElement>, _index: number, portalId: string) {
     const clone = { ...temporaryConfig!! }
     const value = Number(event.target.value)
@@ -134,11 +150,13 @@ function Discovery() {
               settings={temporaryConfig.upnp}
               referenceTime={referenceTime}
               expirySettings={temporaryConfig.upnp.expiry}
+              subscriptionSettings={temporaryConfig.upnp.subscriptions}
               availablePortalIds={upnpDiscovered}
               onEnablePortalChange={handleEnablePortalChange}
               onEnableAllPortalsChange={handleEnableAllPortalsChange}
               defaultExpiryDuration={defaultExpiryDuration}
               onPortalExpiryChange={handlePortalExpiryChange}
+              onPortalSubscriptionChange={handlePortalSubscriptionChange}
             />
           </CForm>
         </CCardBody>

--- a/src/client/views/settings/EditableDeviceList.tsx
+++ b/src/client/views/settings/EditableDeviceList.tsx
@@ -10,7 +10,11 @@ import {
   CFormInput,
   CButton,
 } from "@coreui/react"
-import { AppDataCollectionExpiryConfig, AppDeviceConfig, AppInstallationConfig } from "../../../shared/types"
+import AppDeviceSubscriptionsConfig, {
+  AppDataCollectionExpiryConfig,
+  AppDeviceConfig,
+  AppInstallationConfig,
+} from "../../../shared/types"
 import { AutoExpiryOptionList } from "./AutoExpiryOptionList"
 import { DiscoveredDevice } from "../../../shared/state"
 import { MQTTSubscriptionsOptionList } from "./MQTTSubscriptionsOptionList"
@@ -20,6 +24,7 @@ interface EditableDeviceListProps {
   entries: AppDeviceConfig[] | AppInstallationConfig[]
   referenceTime: number
   expirySettings: (number | undefined)[]
+  subscriptionSettings: AppDeviceSubscriptionsConfig
   onEntryValueChange: (_event: React.ChangeEvent<HTMLInputElement>, _index: number) => void
   onEnableEntryChange: (_event: React.ChangeEvent<HTMLInputElement>, _index: number) => void
   onEnableAllEntriesChange: (_event: React.ChangeEvent<HTMLInputElement>) => void
@@ -75,7 +80,8 @@ export function EditableDeviceList(props: EditableDeviceListProps) {
                   <CTableDataCell>
                     <MQTTSubscriptionsOptionList
                       index={index}
-                      portalId={"xxx"}
+                      portalId={key}
+                      configuredMQTTSubscriptions={props.subscriptionSettings[index]}
                       onSelectionDidChange={props.onPortalSubscriptionChange}
                     />
                   </CTableDataCell>
@@ -134,4 +140,26 @@ export function keyedExpiryToArray(
 ): (number | undefined)[] {
   // @ts-expect-error
   return devices.map((device) => expiry[device.hostName ?? device.portalId])
+}
+
+export function arraySubscriptionsToKeyed(
+  subscriptions: AppDeviceSubscriptionsConfig,
+  devices: AppDeviceConfig[] | AppInstallationConfig[],
+  existingSubscriptions: AppDeviceSubscriptionsConfig = {},
+  discoveredDevices: DiscoveredDevice[] = [],
+): AppDeviceSubscriptionsConfig {
+  const a = Object.fromEntries(
+    discoveredDevices.map((device) => [device.portalId, existingSubscriptions[device.portalId]]),
+  )
+  // @ts-expect-error
+  const b = Object.fromEntries(devices.map((device, i) => [device.hostName ?? device.portalId, subscriptions[i]]))
+  return { ...a, ...b }
+}
+
+export function keyedSubscriptionsToArray(
+  subscriptions: AppDeviceSubscriptionsConfig,
+  devices: AppDeviceConfig[] | AppInstallationConfig[],
+): AppDeviceSubscriptionsConfig {
+  // @ts-expect-error
+  return devices.map((device) => subscriptions[device.hostName ?? device.portalId])
 }

--- a/src/client/views/settings/EditableDeviceList.tsx
+++ b/src/client/views/settings/EditableDeviceList.tsx
@@ -24,7 +24,7 @@ interface EditableDeviceListProps {
   entries: AppDeviceConfig[] | AppInstallationConfig[]
   referenceTime: number
   expirySettings: (number | undefined)[]
-  subscriptionSettings: AppDeviceSubscriptionsConfig
+  mqttSubscriptionsSettings: AppDeviceSubscriptionsConfig
   onEntryValueChange: (_event: React.ChangeEvent<HTMLInputElement>, _index: number) => void
   onEnableEntryChange: (_event: React.ChangeEvent<HTMLInputElement>, _index: number) => void
   onEnableAllEntriesChange: (_event: React.ChangeEvent<HTMLInputElement>) => void
@@ -33,7 +33,11 @@ interface EditableDeviceListProps {
   entryTitleText: string
   addEntryButtonText: string
   defaultExpiryDuration?: number
-  onPortalSubscriptionChange: (_event: React.ChangeEvent<HTMLSelectElement>, _index: number, _portalId: string) => void
+  onPortalMQTTSubscriptionsChange: (
+    _event: React.ChangeEvent<HTMLSelectElement>,
+    _index: number,
+    _portalId: string,
+  ) => void
   onPortalExpiryChange: (_event: React.ChangeEvent<HTMLSelectElement>, _index: number, _portalId: string) => void
 }
 
@@ -81,8 +85,8 @@ export function EditableDeviceList(props: EditableDeviceListProps) {
                     <MQTTSubscriptionsOptionList
                       index={index}
                       portalId={key}
-                      configuredMQTTSubscriptions={props.subscriptionSettings[index]}
-                      onSelectionDidChange={props.onPortalSubscriptionChange}
+                      configuredMQTTSubscriptions={props.mqttSubscriptionsSettings[index]}
+                      onSelectionDidChange={props.onPortalMQTTSubscriptionsChange}
                     />
                   </CTableDataCell>
                   {props.defaultExpiryDuration && (

--- a/src/client/views/settings/EditableDeviceList.tsx
+++ b/src/client/views/settings/EditableDeviceList.tsx
@@ -13,6 +13,7 @@ import {
 import { AppDataCollectionExpiryConfig, AppDeviceConfig, AppInstallationConfig } from "../../../shared/types"
 import { AutoExpiryOptionList } from "./AutoExpiryOptionList"
 import { DiscoveredDevice } from "../../../shared/state"
+import { MQTTSubscriptionsOptionList } from "./MQTTSubscriptionsOptionList"
 
 interface EditableDeviceListProps {
   hidden?: boolean
@@ -27,6 +28,7 @@ interface EditableDeviceListProps {
   entryTitleText: string
   addEntryButtonText: string
   defaultExpiryDuration?: number
+  onPortalSubscriptionChange: (_event: React.ChangeEvent<HTMLSelectElement>, _index: number, _portalId: string) => void
   onPortalExpiryChange: (_event: React.ChangeEvent<HTMLSelectElement>, _index: number, _portalId: string) => void
 }
 
@@ -37,6 +39,7 @@ export function EditableDeviceList(props: EditableDeviceListProps) {
         <CTableHead>
           <CTableRow>
             <CTableHeaderCell>{props.entryTitleText}</CTableHeaderCell>
+            <CTableHeaderCell>Subscription</CTableHeaderCell>
             {props.defaultExpiryDuration && <CTableHeaderCell>Auto Expire Data Collection</CTableHeaderCell>}
             <CTableHeaderCell>
               <CFormCheck
@@ -67,6 +70,13 @@ export function EditableDeviceList(props: EditableDeviceListProps) {
                       placeholder=""
                       value={key}
                       onChange={(event) => props.onEntryValueChange(event, index)}
+                    />
+                  </CTableDataCell>
+                  <CTableDataCell>
+                    <MQTTSubscriptionsOptionList
+                      index={index}
+                      portalId={"xxx"}
+                      onSelectionDidChange={props.onPortalSubscriptionChange}
                     />
                   </CTableDataCell>
                   {props.defaultExpiryDuration && (

--- a/src/client/views/settings/MQTTSubscriptionsOptionList.tsx
+++ b/src/client/views/settings/MQTTSubscriptionsOptionList.tsx
@@ -1,12 +1,12 @@
 import React from "react"
 import { CFormSelect } from "@coreui/react"
 import { useEffect, useState } from "react"
-import { VenusMQTTTopics } from "../../../shared/types"
+import { VenusMQTTTopic, VenusMQTTTopics } from "../../../shared/types"
 
 export interface MQTTSubscriptionsOptionListProps {
   index: number
   portalId: string
-  configuredMQTTSubscription?: string
+  configuredMQTTSubscriptions: VenusMQTTTopic[]
   onSelectionDidChange: (_event: React.ChangeEvent<HTMLSelectElement>, _index: number, _portalId: string) => void
 }
 
@@ -20,18 +20,22 @@ interface MQTTSubscriptionsOptionListOptions {
   options: MQTTSubscriptionsListOption[]
 }
 
-function generateOptions(configuredMQTTSubscription?: string): MQTTSubscriptionsOptionListOptions {
+function generateOptions(configuredMQTTSubscriptions: VenusMQTTTopic[]): MQTTSubscriptionsOptionListOptions {
+  let defaultValue = `/#`
+  if (configuredMQTTSubscriptions && configuredMQTTSubscriptions.length > 0) {
+    defaultValue = configuredMQTTSubscriptions[0]
+  }
   const options = VenusMQTTTopics.map((x) => {
     return { label: x, value: x }
   })
-  return { default: configuredMQTTSubscription || `/#`, options: options }
+  return { default: defaultValue, options: options }
 }
 
 export function MQTTSubscriptionsOptionList(props: MQTTSubscriptionsOptionListProps) {
   const [options, setOptions] = useState<MQTTSubscriptionsOptionListOptions>({ default: "", options: [] })
   useEffect(() => {
-    setOptions(generateOptions(props.configuredMQTTSubscription))
-  }, [props.configuredMQTTSubscription])
+    setOptions(generateOptions(props.configuredMQTTSubscriptions))
+  }, [props.configuredMQTTSubscriptions])
   return (
     <CFormSelect
       options={options.options}

--- a/src/client/views/settings/MQTTSubscriptionsOptionList.tsx
+++ b/src/client/views/settings/MQTTSubscriptionsOptionList.tsx
@@ -1,0 +1,42 @@
+import React from "react"
+import { CFormSelect } from "@coreui/react"
+import { useEffect, useState } from "react"
+import { VenusMQTTTopics } from "../../../shared/types"
+
+export interface MQTTSubscriptionsOptionListProps {
+  index: number
+  portalId: string
+  configuredMQTTSubscription?: string
+  onSelectionDidChange: (_event: React.ChangeEvent<HTMLSelectElement>, _index: number, _portalId: string) => void
+}
+
+interface MQTTSubscriptionsListOption {
+  label: string
+  value: string
+}
+
+interface MQTTSubscriptionsOptionListOptions {
+  default: string
+  options: MQTTSubscriptionsListOption[]
+}
+
+function generateOptions(configuredMQTTSubscription?: string): MQTTSubscriptionsOptionListOptions {
+  const options = VenusMQTTTopics.map((x) => {
+    return { label: x, value: x }
+  })
+  return { default: configuredMQTTSubscription || `/#`, options: options }
+}
+
+export function MQTTSubscriptionsOptionList(props: MQTTSubscriptionsOptionListProps) {
+  const [options, setOptions] = useState<MQTTSubscriptionsOptionListOptions>({ default: "", options: [] })
+  useEffect(() => {
+    setOptions(generateOptions(props.configuredMQTTSubscription))
+  }, [props.configuredMQTTSubscription])
+  return (
+    <CFormSelect
+      options={options.options}
+      value={options.default}
+      onChange={(event) => props.onSelectionDidChange(event, props.index, props.portalId)}
+    />
+  )
+}

--- a/src/client/views/settings/Manual.tsx
+++ b/src/client/views/settings/Manual.tsx
@@ -170,7 +170,7 @@ function Manual() {
               entries={temporaryConfig.manual.hosts}
               referenceTime={referenceTime}
               expirySettings={temporaryExpiry}
-              subscriptionSettings={temporarySubscriptions}
+              mqttSubscriptionsSettings={temporarySubscriptions}
               onEntryValueChange={handleHostNameChange}
               onEnableEntryChange={handleEnableHostChange}
               onEnableAllEntriesChange={handleEnableAllHostsChange}
@@ -180,7 +180,7 @@ function Manual() {
               addEntryButtonText="Add Host"
               defaultExpiryDuration={defaultExpiryDuration}
               onPortalExpiryChange={handlePortalExpiryChange}
-              onPortalSubscriptionChange={handlePortalSubscriptionChange}
+              onPortalMQTTSubscriptionsChange={handlePortalSubscriptionChange}
             />
           </CForm>
         </CCardBody>

--- a/src/client/views/settings/Manual.tsx
+++ b/src/client/views/settings/Manual.tsx
@@ -3,9 +3,15 @@ import { CCard, CCardBody, CCardHeader, CCardFooter, CForm, CButton, CFormCheck 
 
 import { useGetConfig, usePutConfig } from "../../hooks/useAdminApi"
 import { useFormValidation, extractParameterNameAndValue } from "../../hooks/useFormValidation"
-import { arrayExpiryToKeyed, EditableDeviceList, keyedExpiryToArray } from "./EditableDeviceList"
+import {
+  arrayExpiryToKeyed,
+  arraySubscriptionsToKeyed,
+  EditableDeviceList,
+  keyedExpiryToArray,
+  keyedSubscriptionsToArray,
+} from "./EditableDeviceList"
 import { useEffect, useState } from "react"
-import { AppConfig } from "../../../shared/types"
+import AppDeviceSubscriptionsConfig, { AppConfig, VenusMQTTTopic } from "../../../shared/types"
 import { WebSocketStatus } from "./WebsocketStatus"
 import { useSelector } from "react-redux"
 import { AppState } from "../../store"
@@ -29,12 +35,14 @@ function Manual() {
 
   const [referenceTime, setReferenceTime] = useState<number>(0)
   const [temporaryExpiry, setTemporaryExpiry] = useState<(number | undefined)[]>([])
+  const [temporarySubscriptions, setTemporarySubscriptions] = useState<AppDeviceSubscriptionsConfig>({})
   const [temporaryConfig, setTemporaryConfig] = useState<AppConfig>()
   useEffect(() => {
     setReferenceTime(Date.now())
     populateDefaultExpiry(config)
     setTemporaryConfig(config)
     setTemporaryExpiry(keyedExpiryToArray(config?.manual.expiry ?? {}, config?.manual.hosts ?? []))
+    setTemporarySubscriptions(keyedSubscriptionsToArray(config?.manual.subscriptions ?? {}, config?.manual.hosts ?? []))
     setIsTemporaryConfigDirty(false)
   }, [config])
 
@@ -111,6 +119,21 @@ function Manual() {
     setIsTemporaryConfigDirty(true)
   }
 
+  function handlePortalSubscriptionChange(
+    event: React.ChangeEvent<HTMLSelectElement>,
+    index: number,
+    _portalId: string,
+  ) {
+    const clone = { ...temporaryConfig!! }
+    const value = String(event.target.value) as VenusMQTTTopic
+    const newSubscriptions = { ...temporarySubscriptions!! }
+    newSubscriptions[index] = [value]
+    clone.manual.subscriptions = arraySubscriptionsToKeyed(newSubscriptions, clone.manual.hosts)
+    setTemporarySubscriptions(newSubscriptions)
+    setTemporaryConfig(clone)
+    setIsTemporaryConfigDirty(true)
+  }
+
   function handlePortalExpiryChange(event: React.ChangeEvent<HTMLSelectElement>, index: number, _portalId: string) {
     const clone = { ...temporaryConfig!! }
     const value = Number(event.target.value)
@@ -147,6 +170,7 @@ function Manual() {
               entries={temporaryConfig.manual.hosts}
               referenceTime={referenceTime}
               expirySettings={temporaryExpiry}
+              subscriptionSettings={temporarySubscriptions}
               onEntryValueChange={handleHostNameChange}
               onEnableEntryChange={handleEnableHostChange}
               onEnableAllEntriesChange={handleEnableAllHostsChange}
@@ -156,6 +180,7 @@ function Manual() {
               addEntryButtonText="Add Host"
               defaultExpiryDuration={defaultExpiryDuration}
               onPortalExpiryChange={handlePortalExpiryChange}
+              onPortalSubscriptionChange={handlePortalSubscriptionChange}
             />
           </CForm>
         </CCardBody>

--- a/src/client/views/settings/VRM.tsx
+++ b/src/client/views/settings/VRM.tsx
@@ -384,13 +384,13 @@ function VRM() {
                       settings={temporaryConfig.vrm}
                       referenceTime={referenceTime}
                       expirySettings={temporaryConfig.vrm.expiry}
-                      subscriptionSettings={temporaryConfig.vrm.subscriptions}
+                      mqttSubscriptionsSettings={temporaryConfig.vrm.subscriptions}
                       availablePortalIds={vrmDiscovered}
                       onEnablePortalChange={handleEnableDiscoveredPortalChange}
                       onEnableAllPortalsChange={handleEnableAllDiscoveredPortalsChange}
                       defaultExpiryDuration={defaultExpiryDuration}
                       onPortalExpiryChange={handleDiscoveredPortalExpiryChange}
-                      onPortalSubscriptionChange={handleDiscoveredPortalSubscriptionChange}
+                      onPortalMQTTSubscriptionsChange={handleDiscoveredPortalSubscriptionChange}
                     />
                   </CForm>
                   <CButton
@@ -413,7 +413,7 @@ function VRM() {
                       entries={temporaryConfig.vrm.manualPortalIds}
                       referenceTime={referenceTime}
                       expirySettings={temporaryExpiry}
-                      subscriptionSettings={temporarySubscriptions}
+                      mqttSubscriptionsSettings={temporarySubscriptions}
                       onEntryValueChange={handlePortalIdChange}
                       onEnableEntryChange={handleEnableConfiguredPortalChange}
                       onEnableAllEntriesChange={handleEnableAllConfiguredPortalsChange}
@@ -423,7 +423,7 @@ function VRM() {
                       addEntryButtonText="Add Installation"
                       defaultExpiryDuration={defaultExpiryDuration}
                       onPortalExpiryChange={handleConfiguredPortalExpiryChange}
-                      onPortalSubscriptionChange={handleConfiguredPortalSubscriptionChange}
+                      onPortalMQTTSubscriptionsChange={handleConfiguredPortalSubscriptionChange}
                     />
                   </CForm>
                 </CTabPane>

--- a/src/shared/state.ts
+++ b/src/shared/state.ts
@@ -1,4 +1,4 @@
-import { AppConfig, AppUISettings, LogEntry } from "./types"
+import { AppConfig, AppUISettings, LogEntry, VenusMQTTTopic } from "./types"
 
 export type WebSocketActions = "WEBSOCKET_OPEN" | "WEBSOCKET_CLOSE" | "WEBSOCKET_ERROR"
 export type DiscoveryActions = "UPNPDISCOVERY" | "VRMDISCOVERY"
@@ -37,6 +37,7 @@ export type ConfiguredDevice = {
   portalId?: string
   name?: string
   address: string
+  subscriptions: VenusMQTTTopic[]
 }
 
 export interface AppStateUPNPDiscoveryAction extends AppStateBaseAction {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -17,6 +17,7 @@ export interface AppUPNPConfig {
   enabled: boolean
   enabledPortalIds: string[]
   expiry: AppDataCollectionExpiryConfig
+  subscriptions: AppDeviceSubscriptionsConfig
 }
 
 export type AppUPNPConfigKey = keyof AppUPNPConfig
@@ -26,6 +27,7 @@ export interface AppVRMConfig {
   enabledPortalIds: string[]
   manualPortalIds: AppInstallationConfig[]
   expiry: AppDataCollectionExpiryConfig
+  subscriptions: AppDeviceSubscriptionsConfig
   hasToken: boolean
 }
 
@@ -49,9 +51,52 @@ export interface AppManualConfig {
   enabled: boolean
   hosts: AppDeviceConfig[]
   expiry: AppDataCollectionExpiryConfig
+  subscriptions: AppDeviceSubscriptionsConfig
 }
 
 export type AppManualConfigKey = keyof AppManualConfig
+
+// Taken from https://github.com/victronenergy/dbus_modbustcp/blob/master/attributes.csv
+// Using: `cut -d',' -f 1 attributes.csv | sort |  uniq | cut -d '.' -f 3`
+export const VenusMQTTTopics = [
+  `/#`,
+  `/acload/#`,
+  `/acsystem/#`,
+  `/alternator/#`,
+  `/battery/#`,
+  `/charger/#`,
+  `/dcdc/#`,
+  `/dcgenset/#`,
+  `/dcload/#`,
+  `/dcsource/#`,
+  `/dcsystem/#`,
+  `/digitalinput/#`,
+  `/evcharger/#`,
+  `/fuelcell/#`,
+  `/generator/#`,
+  `/genset/#`,
+  `/gps/#`,
+  `/grid/#`,
+  `/hub4/#`,
+  `/inverter/#`,
+  `/meteo/#`,
+  `/motordrive/#`,
+  `/multi/#`,
+  `/pulsemeter/#`,
+  `/pump/#`,
+  `/pvinverter/#`,
+  `/solarcharger/#`,
+  `/system/#`,
+  `/tank/#`,
+  `/temperature/#`,
+  `/vebus/#`,
+] as const
+
+export type VenusMQTTTopic = (typeof VenusMQTTTopics)[number]
+
+export default interface AppDeviceSubscriptionsConfig {
+  [portalId: string]: [VenusMQTTTopic] // MQTT topics to subscribe to
+}
 
 export interface AppDataCollectionExpiryConfig {
   [portalId: string]: number | undefined // absolute time in millis when data collection will expire
@@ -111,11 +156,13 @@ const defaultAppConfigValues: AppConfig = {
     enabled: true,
     enabledPortalIds: [],
     expiry: {},
+    subscriptions: {},
   },
   manual: {
     enabled: true,
     hosts: [],
     expiry: {},
+    subscriptions: {},
   },
   vrm: {
     enabled: true,
@@ -123,6 +170,7 @@ const defaultAppConfigValues: AppConfig = {
     manualPortalIds: [],
     hasToken: false,
     expiry: {},
+    subscriptions: {},
   },
   influxdb: {
     protocol: "http",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -58,7 +58,7 @@ export type AppManualConfigKey = keyof AppManualConfig
 
 // Taken from https://github.com/victronenergy/dbus_modbustcp/blob/master/attributes.csv
 // Using: `cut -d',' -f 1 attributes.csv | sort |  uniq | cut -d '.' -f 3`
-// `/settings/#` added manually
+// `/system/#` and `/settings/#` removed as we always subscribe to them
 export const VenusMQTTTopics = [
   `/#`,
   `/acload/#`,
@@ -87,14 +87,12 @@ export const VenusMQTTTopics = [
   `/pump/#`,
   `/pvinverter/#`,
   `/solarcharger/#`,
-  `/system/#`,
   `/tank/#`,
   `/temperature/#`,
   `/vebus/#`,
-  `/settings/#`,
 ] as const
 
-export type VenusMQTTTopic = (typeof VenusMQTTTopics)[number]
+export type VenusMQTTTopic = (typeof VenusMQTTTopics)[number] | "/system/#" | "/settings/#"
 
 export default interface AppDeviceSubscriptionsConfig {
   [portalId: string]: VenusMQTTTopic[] // MQTT topics to subscribe to

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -58,6 +58,7 @@ export type AppManualConfigKey = keyof AppManualConfig
 
 // Taken from https://github.com/victronenergy/dbus_modbustcp/blob/master/attributes.csv
 // Using: `cut -d',' -f 1 attributes.csv | sort |  uniq | cut -d '.' -f 3`
+// `/settings/#` added manually
 export const VenusMQTTTopics = [
   `/#`,
   `/acload/#`,
@@ -90,12 +91,13 @@ export const VenusMQTTTopics = [
   `/tank/#`,
   `/temperature/#`,
   `/vebus/#`,
+  `/settings/#`,
 ] as const
 
 export type VenusMQTTTopic = (typeof VenusMQTTTopics)[number]
 
 export default interface AppDeviceSubscriptionsConfig {
-  [portalId: string]: [VenusMQTTTopic] // MQTT topics to subscribe to
+  [portalId: string]: VenusMQTTTopic[] // MQTT topics to subscribe to
 }
 
 export interface AppDataCollectionExpiryConfig {


### PR DESCRIPTION
This PR allows per-device override of MQTT subscription, in the initial version to choose what top level tree to watch.

The benefits:

- Receive/store less topics, consume less data, store only what is needed
- Make it easier to create custom Grafana Dashboards since auto complete popup shows only relevant topics

TODO:

- [x] Specify up to date list of top level MQTT topics
- [x] Add option list in the UI to select a top level MQTT topic per device
- [x] UI should retrieve + save configured topics
- [x] Server should parse topics from the config file, load/save support
- [x] Loader should accept configure topics, MQTT subscribe to only configured topics
- [x] Loader should re-subscribe when topics change

<img width="1305" alt="Screenshot 2024-12-06 at 13 40 04" src="https://github.com/user-attachments/assets/d3e488f4-978d-4e74-9e98-364e27b32d86">
