### PR TITLE
feat: Retain VRM config on invalid token

### DIFF
--- a/src/client/views/settings/VRM.tsx
+++ b/src/client/views/settings/VRM.tsx
@@ -349,7 +349,8 @@ function VRM() {
               {temporaryConfig.vrm.hasToken && <span className="text-secondary">VRM Token: {vrmStatus.tokenInfo}</span>}
               {temporaryConfig.vrm.hasToken && vrmStatus.tokenExpires && (
                 <>
-                  <span className="text-secondary">, &nbsp;</span>
+                  {vrmStatus.tokenInfo && <span className="text-secondary">,&nbsp;</span>}
+                  {!vrmStatus.tokenInfo && <span className="text-secondary">&nbsp;</span>}
                   <span
                     className={
                       vrmStatus.tokenExpires < 7 * 24 * 60 * 60 * 1000
@@ -359,7 +360,10 @@ function VRM() {
                           : "text-secondary"
                     }
                   >
-                    expires in: {ms(vrmStatus.tokenExpires, { long: true })}
+                    {vrmStatus.tokenExpires > 0 && (
+                      <span>expires in: {ms(vrmStatus.tokenExpires, { long: true })}</span>
+                    )}
+                    {vrmStatus.tokenExpires <= 0 && <span>expired</span>}
                   </span>
                 </>
               )}

--- a/src/server/vrm.ts
+++ b/src/server/vrm.ts
@@ -84,6 +84,13 @@ export class VRM {
 
       // validate & parse response
       if (res.status == 200) {
+        // if another VRM user logged in, delete previous VRM config
+        if (response.idUser !== this.server.secrets.vrmUserId) {
+          this.server.config.vrm.enabledPortalIds = []
+          this.server.config.vrm.manualPortalIds = []
+          this.server.config.vrm.expiry = {}
+          this.server.config.vrm.subscriptions = {}
+        }
         this.server.secrets.vrmUsername = username
         this.server.secrets.vrmUserId = response.idUser
       } else {
@@ -144,6 +151,13 @@ export class VRM {
 
       // validate & parse response
       if (res.status == 200 && response.success === true) {
+        // if another VRM user logged in, delete previous VRM config
+        if (response.user.id !== this.server.secrets.vrmUserId) {
+          this.server.config.vrm.enabledPortalIds = []
+          this.server.config.vrm.manualPortalIds = []
+          this.server.config.vrm.expiry = {}
+          this.server.config.vrm.subscriptions = {}
+        }
         this.server.secrets.vrmToken = token
         this.server.secrets.vrmUserId = response.user.id
         this.server.secrets.vrmUsername = response.user.email
@@ -177,15 +191,12 @@ export class VRM {
       this.fail(`Logout failed: ${error}`)
     }
 
-    // NOTE: we do not check response code,
-    // we simply delete secrets, and forget enabled portals
+    // NOTE: we do not check the response code,
+    // delete vrm token, but leave vrm username + config around
+    // so that new VRM login with fresh token will retain the config
+    // if the vrmUserId matches previous config
     delete this.server.secrets.vrmToken
     delete this.server.secrets.vrmTokenId
-    delete this.server.secrets.vrmUserId
-    delete this.server.secrets.vrmUsername
-    this.server.config.vrm.enabledPortalIds = []
-    this.server.config.vrm.manualPortalIds = []
-    this.server.config.vrm.expiry = {}
     this.server.config.vrm.hasToken = false
     await this.server.saveSecrets()
     await this.server.saveConfig()

--- a/src/server/vrm.ts
+++ b/src/server/vrm.ts
@@ -227,7 +227,7 @@ export class VRM {
       if (error instanceof AxiosError && error.status === 401) {
         reason = `invalid or expired VRM Token (${error})`
       }
-      this.fail(`Validating VRM Token failed: ${reason}`)
+      this.fail(`Validating VRM Token failed: ${reason}`, ``, -1000)
       throw error
     }
 


### PR DESCRIPTION
This PR fixes #320.

Previously when a VRM token expired or was deleted, the Influx Loader UI would properly detect that by flagging the token as invalid. This then required to `Logout` and `Login` with a new token. `Logout` would delete all VRM related configuration and custom subscriptions. Making all the config necessary after new login.

This PR changes the logic, so `Logout` no longer deletes the VRM related config but retains it until next `Login` operation. After successful login it checks what user has logged in, and if it is the same user that created the config originally it continues using it.

This makes it possible to `Logout`, and `Login` with a fresh token without loosing all custom configuration.

When VRM token is nearing expiration, we display that in Influx Loader UI:
<img width="1022" alt="Screenshot 2025-05-13 at 11 46 36" src="https://github.com/user-attachments/assets/2c646791-80b1-4eb0-b6e2-2749a780d600" />

When VRM token is deleted or expired, we now display that in Influx Loader UI as well:
<img width="1022" alt="Screenshot 2025-05-13 at 11 46 55" src="https://github.com/user-attachments/assets/9f074358-f94c-4cf0-b896-ac2ee923873d" />

